### PR TITLE
Add dynamic name input demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,12 @@ harmony
 #### Procedural Drawing Tool ####
 
 [![Flattr this](http://api.flattr.com/button/button-compact-static-100x17.png)](http://flattr.com/thing/288/harmony)
+
+### Demo
+
+A dynamic name input demo is available in `demo/index.html`. Open it in your browser or start a local server:
+
+```bash
+npx serve demo
+```
+

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Dynamic Name Input Demo</title>
+  <style>
+    body { font-family: sans-serif; padding: 2rem; }
+    .hidden { display: none; }
+    .bounce { animation: bounceIn 0.4s ease; }
+    @keyframes bounceIn {
+      0% { transform: scale(0.9); opacity: 0; }
+      60% { transform: scale(1.05); opacity: 1; }
+      100% { transform: scale(1); }
+    }
+    input { margin: 0.25rem 0; padding: 0.25rem; }
+  </style>
+</head>
+<body>
+  <h1>Dynamic Name Input Demo</h1>
+  <p>Click the field below to edit the individual name components.</p>
+  <div class="name-input">
+    <input id="fullNameDisplay" readonly />
+    <div id="nameFields" class="hidden bounce">
+      <input id="prefix" placeholder="Mr./Ms." />
+      <input id="first" placeholder="First" />
+      <input id="middle" placeholder="Middle" />
+      <input id="last" placeholder="Last" />
+      <input id="suffix" placeholder="Jr./MD" />
+    </div>
+  </div>
+
+  <script>
+    const display = document.getElementById('fullNameDisplay');
+    const fields  = document.getElementById('nameFields');
+    const inputs  = [...fields.querySelectorAll('input')];
+
+    function updateDisplay() {
+      const [pref, first, middle, last, suff] = inputs.map(i => i.value.trim());
+      display.value = [pref, first, middle, last, suff].filter(Boolean).join(' ');
+    }
+
+    display.addEventListener('focus', () => {
+      display.classList.add('hidden');
+      fields.classList.remove('hidden');
+      fields.classList.add('bounce');
+      inputs[0].focus();
+    });
+
+    function collapse() {
+      updateDisplay();
+      fields.classList.add('hidden');
+      display.classList.remove('hidden');
+    }
+
+    inputs.forEach(i => i.addEventListener('blur', () => {
+      if (!fields.contains(document.activeElement)) collapse();
+    }));
+
+    inputs.forEach(i => i.addEventListener('keydown', e => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        collapse();
+      }
+    }));
+
+    updateDisplay();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone demo showing dynamic split/combine name input
- document how to run the demo in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8cb041b083328a6b5e7dc4a5fd07